### PR TITLE
Docs update - 1.2.0

### DIFF
--- a/Writerside/n.tree
+++ b/Writerside/n.tree
@@ -17,6 +17,7 @@
         <toc-element topic="check-update.md"/>
         <toc-element topic="inertia-fix.md"/>
         <toc-element topic="ios-install.md"/>
+        <toc-element topic="mobile-install.md"/>
         <toc-element topic="self-update.md"/>
         <toc-element topic="update.md"/>
     </toc-element>

--- a/Writerside/topics/inertia-fix.md
+++ b/Writerside/topics/inertia-fix.md
@@ -1,5 +1,11 @@
 # inertia:fix
 
+<warning>
+This command was temporarily added whilst awaiting a blocking change to be merged into the InertiaJS repository.
+
+This command was added in version 1.1.2 and was subsequently removed in version 1.2.0.
+</warning>
+
 This command is provided to assist those using [NativePHP for Mobile](https://nativephp.com/mobile) to fix the ongoing InertiaJS issue with the `nativecli` command.
 
 This command will remove the `@inertiajs/*` package from your project and then re-install it from a [patch provided by Marcel Pociot](https://github.com/inertiajs/inertia/pull/2329).

--- a/Writerside/topics/mobile-install.md
+++ b/Writerside/topics/mobile-install.md
@@ -1,15 +1,9 @@
-# ios:install
+# mobile:install
 
 <warning>
 This command requires that you have a license from NativePHP.
-If you do not have a license, you can purchase one from <a href="https://nativephp.com/mobile" />.
+If you do not have a license, you can purchase one from <a href="https://nativephp.com/ios" />.
 </warning>
-
-<tip>
-This command was available until version 1.1.2.
-
-From version 1.2.0, you should use <a href="mobile-install.md" summary="mobile:install"> instead.
-</tip>
 
 This command will bootstrap your existing Laravel app with the NativePHP for iOS package, ready for you to build your iOS app.
 
@@ -20,7 +14,7 @@ If you have not previously installed the NativePHP for iOS package, you will be 
 Syntax:
 
 ```shell
-nativecli ios:install
+nativecli mobile:install
 ```
 
 ## Options


### PR DESCRIPTION
This pull request updates the documentation for NativePHP commands, particularly focusing on the transition from platform-specific commands to a unified `mobile:install` command. The changes include adding a new topic for the `mobile:install` command, updating references in related topics, and providing version-specific notes for deprecated commands.

### Additions and Updates to Command Documentation:

* **New Command Documentation:**
  - Added a new topic `mobile-install.md` documenting the `mobile:install` command, which replaces the platform-specific commands for bootstrapping Laravel apps with NativePHP for iOS.
  - Included syntax, usage, and a warning about the license requirement.

* **Updates to Existing Topics:**
  - Updated `ios-install.md` to reflect that the `ios:install` command is deprecated as of version 1.2.0 and replaced by `mobile:install`. Added a tip with a link to the new command.
  - Added a warning in `inertia-fix.md` explaining that the `inertia:fix` command was temporary and has been removed as of version 1.2.0.

### Table of Contents Update:

* Added `mobile-install.md` to the table of contents in `Writerside/n.tree`.